### PR TITLE
update to use files and exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,15 @@
     "type": "git",
     "url": "https://github.com/kisonecat/math-expressions"
   },
-  "main": "build/math-expressions_umd.js",
-  "jsnext:main": "build/math-expressions.js",
+  "files": [
+    "/build"
+  ],
+  "exports": {
+    ".": {
+      "import": "./build/math-expressions.js",
+      "require": "./build/math-expressions_umd.js"
+    }
+  },
   "private": false,
   "dependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
using the main field cuases issues with rollup due to commonjs transpiling. Exports allows for use of both `require` statements and ems `import`.