### PR TITLE
Add CI workflow to run all tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run all tests
+        run: npm run test:all


### PR DESCRIPTION
Adds a GitHub Actions CI workflow that runs the full test suite.

## Details
- **Triggers**: pushes to `main` and `pull_request` events from any branch
- **Job**: checks out the repo, sets up Node 24 with npm caching, runs `npm ci`, then `npm run test:all` (`jest` with no filter)
- Action versions are the current latest: `actions/checkout@v6` and `actions/setup-node@v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)