### PR TITLE
Bump version to 2.0.0-alpha94

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "math-expressions",
-  "version": "2.0.0-alpha93",
+  "version": "2.0.0-alpha94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "math-expressions",
-      "version": "2.0.0-alpha93",
+      "version": "2.0.0-alpha94",
       "license": "(GPL-3.0 OR Apache-2.0)",
       "dependencies": {
         "mathjs": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "math-expressions",
   "description": "Perform basic equality testing and symbolic computations on mathematical expressions involving transcendental functions",
-  "version": "2.0.0-alpha93",
+  "version": "2.0.0-alpha94",
   "type": "module",
   "author": {
     "name": "Jim Fowler",


### PR DESCRIPTION
Bumps version from `2.0.0-alpha93` to `2.0.0-alpha94` following the merge of:

- #67 Devcontainer
- #68 Switch to Vite (removes `babel-upgrade`, `@babel/cli` from production deps; eliminates the babel toolchain security vulnerabilities)

The build artifacts in `build/` are unchanged from what was committed in #68.

Security improvement: vulnerability count dropped from 31 (4 CRITICAL, 14 HIGH) to 5 (0 CRITICAL, all in dev-only `jshint`).

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)