### PR TITLE
Publish `numeric` on the global object so browsers can use it

### DIFF
--- a/lib/mathjs.js
+++ b/lib/mathjs.js
@@ -1,6 +1,20 @@
 import { create, all } from "mathjs";
 import numeric from "numeric";
 
+// numeric.js builds most of its helpers at load time with the `Function`
+// constructor, and the generated bodies reference a bare `numeric` (e.g.
+// `_s = numeric.dim(x)`). Those functions are evaluated in global scope, so the
+// reference resolves only if `numeric` is a property of the global object.
+// numeric.js puts it there itself — but only through `global`, which exists in
+// Node and nowhere else, so in a browser or a web worker every generated helper
+// throws `ReferenceError: numeric is not defined` the first time it is called.
+// Publish it ourselves so the generated code resolves wherever this runs.
+//
+// Assigned unconditionally rather than only when `globalThis.numeric` is unset:
+// on a page with an element whose id is `numeric`, the named-element global
+// makes it look occupied while still being useless to the generated code.
+globalThis.numeric = numeric;
+
 export function createInstance({
   define_e = true,
   define_pi = true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "math-expressions",
-  "version": "2.0.0-alpha94",
+  "version": "2.0.0-alpha95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "math-expressions",
-      "version": "2.0.0-alpha94",
+      "version": "2.0.0-alpha95",
       "license": "(GPL-3.0 OR Apache-2.0)",
       "dependencies": {
         "mathjs": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "math-expressions",
   "description": "Perform basic equality testing and symbolic computations on mathematical expressions involving transcendental functions",
-  "version": "2.0.0-alpha94",
+  "version": "2.0.0-alpha95",
   "type": "module",
   "author": {
     "name": "Jim Fowler",

--- a/spec/quick_numeric-global.spec.js
+++ b/spec/quick_numeric-global.spec.js
@@ -1,0 +1,44 @@
+// numeric.js builds most of its helpers at load time with the `Function`
+// constructor, and the generated bodies reference a bare `numeric` (e.g.
+// `_s = numeric.dim(x)`). Those functions are evaluated in global scope, so
+// that reference resolves only if `numeric` is a property of the global object.
+// numeric.js publishes itself there through Node's `global`, which does not
+// exist in a browser or a web worker — so `lib/mathjs.js` has to publish it.
+//
+// Running under Node, `global` is present and numeric would register itself
+// anyway, which would make this test pass with or without that code. So delete
+// `global` before the first import to reproduce the shape a browser sees.
+
+describe("numeric's global registration", function () {
+  let hadGlobal, savedGlobal, hadNumeric, savedNumeric;
+
+  beforeEach(function () {
+    hadGlobal = "global" in globalThis;
+    savedGlobal = globalThis.global;
+    hadNumeric = "numeric" in globalThis;
+    savedNumeric = globalThis.numeric;
+  });
+
+  afterEach(function () {
+    if (hadGlobal) globalThis.global = savedGlobal;
+    else delete globalThis.global;
+    if (hadNumeric) globalThis.numeric = savedNumeric;
+    else delete globalThis.numeric;
+  });
+
+  it("survives a runtime with no `global`", async function () {
+    delete globalThis.global;
+    delete globalThis.numeric;
+
+    const { default: math } = await import("../lib/mathjs.js");
+
+    expect(globalThis.numeric).toBeTypeOf("object");
+    expect(globalThis.numeric.dim).toBeTypeOf("function");
+
+    // `dopri` reaches numeric's generated `add`/`mul`/`sub` helpers, so it
+    // throws `ReferenceError: numeric is not defined` if the registration is
+    // missing. x' = x from x(0) = 1 integrates to e.
+    const solution = math.dopri(0, 1, [1], (t, x) => [x[0]], 1e-6, 1000);
+    expect(solution.at(1)[0]).toBeCloseTo(Math.E, 5);
+  });
+});


### PR DESCRIPTION
`me.math.dopri` throws `ReferenceError: numeric is not defined` in a browser and in a web worker, while working fine under Node. DoenetML's `<odeSystem>` integrates with it, so every activity containing an ODE currently dies on load — the worker error surfaces as a red "numeric is not defined" banner in place of the document.

### Why

numeric.js builds most of its helpers at load time with the `Function` constructor. The generated bodies reference a bare `numeric`:

```js
if(typeof _s === "undefined") _s = numeric.dim(x);
```

Functions made with `Function(...)` are evaluated in **global scope**, so that reference resolves only if `numeric` is a property of the global object. numeric.js puts it there itself — but through a Node-ism:

```js
if (typeof global !== "undefined") { global.numeric = numeric; }
```

A browser main thread and a web worker both have no `global`, so the assignment is skipped and every generated helper (`add`, `mul`, `sub`, `dim`, …) throws the first time it is called. `dopri` reaches those helpers immediately.

### The change

`lib/mathjs.js` — the one place that imports numeric — publishes it itself, which covers every runtime.

The assignment is unconditional rather than guarded on `globalThis.numeric === undefined`. On a page holding an element whose id is `numeric`, the named-element global makes the slot look occupied while still being useless to the generated code — which is exactly what happens in DoenetML, whose virtual keyboard has a `numeric` button, and it turns the error into the more puzzling `dim is not a function`.

### Test

`spec/quick_numeric-global.spec.js` deletes `global` before the first import of `lib/mathjs.js`, reproducing the shape a browser sees, then integrates x' = x from x(0) = 1 and checks it lands on e. Without the fix it fails with the production error:

```
ReferenceError: numeric is not defined
 ❯ eval node_modules/numeric/numeric-1.2.6.js:696:26
 ❯ Object.dopri node_modules/numeric/numeric-1.2.6.js:2916:49
```

`npm test` is green (3580 tests, 19 files). Verified end to end against DoenetML: with the equivalent shim in place, an `<odeSystem>` document renders its values and plots its solution curve in both the worker and the main-thread renderer.

### Base branch

Against `2.x`, branched from `v2.0.0-alpha94` — the published 2.x line that DoenetML consumes. `main` no longer contains `lib/mathjs.js`; the Rust port (#77) removed it. A companion PR, #87, restores numeric in `packages/math-expressions-js-compat` on `main`, where `me.math` currently has no `dopri` at all.

A second commit bumps the version to `2.0.0-alpha95`, so this can be published as soon as it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
